### PR TITLE
Start of Adminstration to add and delete Admins

### DIFF
--- a/src/app/admin/administration/administration.component.html
+++ b/src/app/admin/administration/administration.component.html
@@ -4,12 +4,31 @@
             <h1 class="text-center">Administration</h1>
 
             <div class="col-xs-6 col-md-3 col-md-offset-3 text-center">
-                <button class="btn btn-primary" style="margin-right: 15px;" (click)="addAdmin()">Add Admin</button>
+                <button class="btn btn-primary" style="margin-right: 15px;" (click)="showAddAdmin()">Add Admin</button>
             </div>
             <div class="col-xs-6 col-md-6">
-                <button class="btn btn-primary" (click)="deleteAdmin()">Delete Admin</button>
+                <button class="btn btn-primary" (click)="showDeleteAdmin()">Delete Admin</button>
             </div>
 
         </div>
     </div>
+
+    <div class="col-xs-12 col-md-6 col-md-offset-3" *ngIf="addFlag">
+        <h3 class="text-center">Select Person to Make an Admin</h3>
+        <div class="col-md-6 col-xs-12 col-md-offset-3">
+            <div *ngFor="let speaker of (speakerService.speakers | async)" class="speaker" (click)="addAdmin(speaker._id)">
+                <div class="nameEntry"><b>Name:</b> &nbsp;&nbsp;{{ speaker.nameFirst }} {{ speaker.nameLast }}</div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-xs-12 col-md-6 col-md-offset-3" *ngIf="deleteFlag">
+        <h3 class="text-center">Select Admin to Delete</h3>
+        <div class="col-md-6 col-xs-12 col-md-offset-3">
+            <div *ngFor="let speaker of (speakerService.speakers | async)" class="speaker" (click)="addAdmin(speaker._id)">
+                <div class="nameEntry"><b>Name:</b> &nbsp;&nbsp;{{ speaker.nameFirst }} {{ speaker.nameLast }}</div>
+            </div>
+        </div>
+    </div>
+
 </div>

--- a/src/app/admin/administration/administration.component.html
+++ b/src/app/admin/administration/administration.component.html
@@ -1,0 +1,15 @@
+<div class="container" [class.page-transition]="transitionService.isTransitioning()">
+    <div class="row">
+        <div class="col-xs-12 col-md-6 col-md-offset-3">
+            <h1 class="text-center">Administration</h1>
+
+            <div class="col-xs-6 col-md-3 col-md-offset-3 text-center">
+                <button class="btn btn-primary" style="margin-right: 15px;" (click)="addAdmin()">Add Admin</button>
+            </div>
+            <div class="col-xs-6 col-md-6">
+                <button class="btn btn-primary" (click)="deleteAdmin()">Delete Admin</button>
+            </div>
+
+        </div>
+    </div>
+</div>

--- a/src/app/admin/administration/administration.component.scss
+++ b/src/app/admin/administration/administration.component.scss
@@ -1,2 +1,5 @@
 @import '../../shared/common-styles';
 
+.nameEntry {
+  line-height: 1.4em;
+}

--- a/src/app/admin/administration/administration.component.scss
+++ b/src/app/admin/administration/administration.component.scss
@@ -1,0 +1,2 @@
+@import '../../shared/common-styles';
+

--- a/src/app/admin/administration/administration.component.ts
+++ b/src/app/admin/administration/administration.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+
+import { TransitionService } from '../../shared/transition.service';
+import { ToastComponent } from '../../shared/toast.component';
+
+@Component({
+               moduleId: module.id,
+               selector: 'administration',
+               templateUrl: 'administration.component.html',
+               styleUrls: ['administration.component.css'],
+               directives: [ToastComponent, ROUTER_DIRECTIVES]
+           })
+
+export class AdministrationComponent implements OnInit {
+
+    @ViewChild('toast') toast: ToastComponent;
+
+    constructor(private transitionService: TransitionService,
+                private router: Router) { }
+
+    ngOnInit() {
+        this.transitionService.transition();
+    }
+
+    addAdmin() {
+        this.router.navigate(['/signup']);
+    }
+
+    deleteAdmin() {
+        this.router.navigate(['/login']);
+    }
+
+}

--- a/src/app/admin/administration/administration.component.ts
+++ b/src/app/admin/administration/administration.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { ROUTER_DIRECTIVES, Router } from '@angular/router';
 
+import { SpeakerService } from '../../shared/speaker.service';
 import { TransitionService } from '../../shared/transition.service';
 import { ToastComponent } from '../../shared/toast.component';
 
@@ -15,20 +16,29 @@ import { ToastComponent } from '../../shared/toast.component';
 export class AdministrationComponent implements OnInit {
 
     @ViewChild('toast') toast: ToastComponent;
+    addFlag = false;
+    deleteFlag = false;
 
     constructor(private transitionService: TransitionService,
+                private speakerService: SpeakerService,
                 private router: Router) { }
 
     ngOnInit() {
         this.transitionService.transition();
     }
 
-    addAdmin() {
-        this.router.navigate(['/signup']);
+    showAddAdmin() {
+        this.addFlag = true;
+        this.deleteFlag = false;
     }
 
-    deleteAdmin() {
-        this.router.navigate(['/login']);
+    showDeleteAdmin() {
+        this.addFlag = false;
+        this.deleteFlag = true;
+    }
+
+    addAdmin(speakerId: string) {
+        this.router.navigate(['/speaker', {id: speakerId}]);
     }
 
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -29,6 +29,7 @@
             <ul class="dropdown-menu" role="menu">
               <li><a [routerLink]="['/speaker', { id: user?._id }]">Edit Profile</a></li>
               <li><a [routerLink]="['/settings']">Change Password</a></li>
+              <li *ngIf="user && user.admin"><a [routerLink]="['/administration']">Administration</a></li>
               <li><a id="logout" (click)="logout()">Logout</a></li>
             </ul>
           </li>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -17,22 +17,24 @@ import { LoginComponent } from './auth/login/login.component';
 import { SignupComponent } from './auth/signup/signup.component';
 import { SettingsComponent } from './auth/settings/settings.component';
 import { LandingComponent } from './auth/landing/landing.component';
+import { AdministrationComponent } from './admin/administration/administration.component';
 
 export const routes: RouterConfig = [
-  { path: '',              component: LandingComponent },
-  { path: 'home',          component: HomeComponent, canActivate: [AdminGuard] },
-  { path: 'calendar',      component: CalendarComponent, canActivate: [AdminGuard] },
-  { path: 'create-conf',   component: CreateConfComponent, canActivate: [AdminGuard] },
-  { path: 'dashboard',     component: DashboardComponent, canActivate: [SpeakerGuard] },
-  { path: 'modify-conf',   component: ModifyConfComponent, canActivate: [AdminGuard] },
-  { path: 'select-active', component: SelectActiveComponent, canActivate: [AdminGuard] },
-  { path: 'session',       component: SessionComponent, canActivate: [SpeakerGuard] },
-  { path: 'session-list',  component: SessionListComponent, canActivate: [AdminGuard] },
-  { path: 'speaker',       component: SpeakerComponent, canActivate: [SpeakerGuard] },
-  { path: 'speaker-list',  component: SpeakerListComponent, canActivate: [AdminGuard] },
-  { path: 'login',         component: LoginComponent },
-  { path: 'signup',        component: SignupComponent },
-  { path: 'settings',      component: SettingsComponent, canActivate: [SpeakerGuard] }
+  { path: '',                 component: LandingComponent },
+  { path: 'home',             component: HomeComponent, canActivate: [AdminGuard] },
+  { path: 'calendar',         component: CalendarComponent, canActivate: [AdminGuard] },
+  { path: 'create-conf',      component: CreateConfComponent, canActivate: [AdminGuard] },
+  { path: 'dashboard',        component: DashboardComponent, canActivate: [SpeakerGuard] },
+  { path: 'modify-conf',      component: ModifyConfComponent, canActivate: [AdminGuard] },
+  { path: 'select-active',    component: SelectActiveComponent, canActivate: [AdminGuard] },
+  { path: 'session',          component: SessionComponent, canActivate: [SpeakerGuard] },
+  { path: 'session-list',     component: SessionListComponent, canActivate: [AdminGuard] },
+  { path: 'speaker',          component: SpeakerComponent, canActivate: [SpeakerGuard] },
+  { path: 'speaker-list',     component: SpeakerListComponent, canActivate: [AdminGuard] },
+  { path: 'login',            component: LoginComponent },
+  { path: 'signup',           component: SignupComponent },
+  { path: 'settings',         component: SettingsComponent, canActivate: [SpeakerGuard] },
+  { path: 'administration',   component: AdministrationComponent, canActivate: [AdminGuard] },
 ];
 
 export const APP_ROUTER_PROVIDERS = [


### PR DESCRIPTION
Started administration section. This will allow anyone with admin access the ability to select any user and make them an admin. Currently it shows list of all users but the ability to click on one to make and admin is currently not working.

Also shows list of all users that you can delete as an admin. This should show only users that have role of admin and not all users.

Merging so that the functionality can be shown to Brooke even though it is not complete.
