### PR TITLE
Upgrade to Angular rc-6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,16 +13,15 @@
     "node": "4.3.1"
   },
   "dependencies": {
-    "@angular/common": "2.0.0-rc.3",
-    "@angular/compiler": "2.0.0-rc.3",
-    "@angular/core": "2.0.0-rc.3",
-    "@angular/forms": "0.3.0",
-    "@angular/http": "2.0.0-rc.3",
-    "@angular/platform-browser": "2.0.0-rc.3",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.3",
-    "@angular/router": "3.0.0-alpha.8",
-    "@angular/router-deprecated": "2.0.0-rc.2",
-    "@angular/upgrade": "2.0.0-rc.3",
+    "@angular/common": "2.0.0-rc.6",
+    "@angular/compiler": "2.0.0-rc.6",
+    "@angular/core": "2.0.0-rc.6",
+    "@angular/forms": "2.0.0-rc.6",
+    "@angular/http": "2.0.0-rc.6",
+    "@angular/platform-browser": "2.0.0-rc.6",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.6",
+    "@angular/router": "3.0.0-rc.2",
+    "@angular/upgrade": "2.0.0-rc.6",
     "angular2-in-memory-web-api": "0.0.5",
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "^1.15.0",
@@ -47,9 +46,9 @@
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.11",
     "systemjs": "0.19.31",
-    "zone.js": "0.6.12"
+    "zone.js": "0.6.17"
   },
   "devDependencies": {
     "dotenv": "^2.0.0",

--- a/src/app/admin/administration/administration.component.ts
+++ b/src/app/admin/administration/administration.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+import { Router } from '@angular/router';
 
 import { SpeakerService } from '../../shared/speaker.service';
 import { TransitionService } from '../../shared/transition.service';
@@ -9,8 +9,7 @@ import { ToastComponent } from '../../shared/toast.component';
                moduleId: module.id,
                selector: 'administration',
                templateUrl: 'administration.component.html',
-               styleUrls: ['administration.component.css'],
-               directives: [ToastComponent, ROUTER_DIRECTIVES]
+               styleUrls: ['administration.component.css']
            })
 
 export class AdministrationComponent implements OnInit {

--- a/src/app/admin/calendar/calendar.component.ts
+++ b/src/app/admin/calendar/calendar.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
-import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+import { Router } from '@angular/router';
 
 import { AdminService } from '../../shared/admin.service';
 import { Conference, TimeSlot } from '../../shared/conference.model';
@@ -18,9 +18,7 @@ declare var $: any;
   moduleId: module.id,
   selector: 'calendar',
   templateUrl: 'calendar.component.html',
-  styleUrls: ['calendar.component.css'],
-  directives: [ToastComponent, ROUTER_DIRECTIVES],
-  pipes: [TimePipe, DatePipe]
+  styleUrls: ['calendar.component.css']
 })
 export class CalendarComponent implements OnInit, AfterViewInit {
 

--- a/src/app/admin/create-conf/create-conf.component.ts
+++ b/src/app/admin/create-conf/create-conf.component.ts
@@ -11,8 +11,7 @@ import { ToastComponent } from '../../shared/toast.component';
   moduleId: module.id,
   selector: 'create-conf',
   templateUrl: 'create-conf.component.html',
-  styleUrls: ['create-conf.component.css'],
-  directives: [ToastComponent]
+  styleUrls: ['create-conf.component.css']
 })
 export class CreateConfComponent implements OnInit {
 

--- a/src/app/admin/home/home.component.ts
+++ b/src/app/admin/home/home.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { ROUTER_DIRECTIVES } from '@angular/router';
 
 import { TransitionService } from '../../shared/transition.service';
 
@@ -7,8 +6,7 @@ import { TransitionService } from '../../shared/transition.service';
   moduleId: module.id,
   selector: 'home',
   templateUrl: 'home.component.html',
-  styleUrls: ['home.component.css'],
-  directives: [ROUTER_DIRECTIVES]
+  styleUrls: ['home.component.css']
 })
 export class HomeComponent implements OnInit {
 

--- a/src/app/admin/modify-conf/modify-conf.component.ts
+++ b/src/app/admin/modify-conf/modify-conf.component.ts
@@ -15,9 +15,7 @@ import { ToastComponent } from '../../shared/toast.component';
   moduleId: module.id,
   selector: 'modify-conf',
   templateUrl: 'modify-conf.component.html',
-  styleUrls: ['modify-conf.component.css'],
-  directives: [ToastComponent],
-  pipes: [TimePipe]
+  styleUrls: ['modify-conf.component.css']
 })
 export class ModifyConfComponent implements OnInit, AfterViewInit {
 

--- a/src/app/admin/select-active/select-active.component.ts
+++ b/src/app/admin/select-active/select-active.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
-import { ROUTER_DIRECTIVES } from '@angular/router';
 
 import { AdminService } from '../../shared/admin.service';
 import { TransitionService } from '../../shared/transition.service';
@@ -9,8 +8,7 @@ import { ToastComponent } from '../../shared/toast.component';
   moduleId: module.id,
   selector: 'select-active',
   templateUrl: 'select-active.component.html',
-  styleUrls: ['select-active.component.css'],
-  directives: [ROUTER_DIRECTIVES, ToastComponent]
+  styleUrls: ['select-active.component.css']
 })
 export class SelectActiveComponent implements OnInit, AfterViewInit {
 

--- a/src/app/admin/session-list/session-list.component.ts
+++ b/src/app/admin/session-list/session-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+import { Router } from '@angular/router';
 
 import { SessionService } from '../../shared/session.service';
 import { TransitionService } from '../../shared/transition.service';
@@ -8,8 +8,7 @@ import { TransitionService } from '../../shared/transition.service';
   moduleId: module.id,
   selector: 'session-list',
   templateUrl: 'session-list.component.html',
-  styleUrls: ['session-list.component.css'],
-  directives: [ROUTER_DIRECTIVES]
+  styleUrls: ['session-list.component.css']
 })
 export class SessionListComponent implements OnInit {
 

--- a/src/app/admin/speaker-list/speaker-list.component.ts
+++ b/src/app/admin/speaker-list/speaker-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+import { Router } from '@angular/router';
 
 import { CapitalizePipe } from '../../shared/capitalize.pipe';
 import { SpeakerService } from '../../shared/speaker.service';
@@ -9,9 +9,7 @@ import { TransitionService } from '../../shared/transition.service';
   moduleId: module.id,
   selector: 'speaker-list',
   templateUrl: 'speaker-list.component.html',
-  styleUrls: ['speaker-list.component.css'],
-  directives: [ROUTER_DIRECTIVES],
-  pipes: [CapitalizePipe]
+  styleUrls: ['speaker-list.component.css']
 })
 export class SpeakerListComponent implements OnInit {
   

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+import { Router } from '@angular/router';
 
 import { AdminService } from './shared/admin.service';
 import { AuthService } from './shared/auth.service';
@@ -12,10 +12,7 @@ import { TransitionService } from './shared/transition.service';
   moduleId: module.id,
   selector: 'my-app',
   templateUrl: 'app.component.html',
-  styleUrls: ['app.component.css'],
-  directives: [ROUTER_DIRECTIVES],
-  providers: [AdminService, DateService, SessionService, 
-              SpeakerService, TransitionService]
+  styleUrls: ['app.component.css']
 })
 export class AppComponent implements OnInit {
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule  } from '@angular/platform-browser';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
 import { routing } from './app.routing';
@@ -48,6 +48,7 @@ import { TimePipe } from './shared/time.pipe';
   imports: [
     BrowserModule,
     FormsModule,
+    ReactiveFormsModule,
     HttpModule,
     routing
   ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { SettingsComponent } from './auth/settings/settings.component';
 import { LandingComponent } from './auth/landing/landing.component';
 import { AdministrationComponent } from './admin/administration/administration.component';
 import { ForgotPasswordComponent } from './auth/forgotpassword/forgotpassword.component';
+import { ToastComponent } from './shared/toast.component';
 
 /** App-wide Services */
 import { AdminService } from './shared/admin.service';
@@ -56,7 +57,7 @@ import { TimePipe } from './shared/time.pipe';
     DashboardComponent, ModifyConfComponent, SelectActiveComponent, SessionComponent,
     SessionListComponent, SpeakerComponent, SpeakerListComponent, LoginComponent,
     SignupComponent, SettingsComponent, LandingComponent, AdministrationComponent, 
-    ForgotPasswordComponent,
+    ForgotPasswordComponent, ToastComponent,
 
     // Pipes
     DatePipe, CapitalizePipe, TimePipe

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,74 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule  } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+import { HttpModule } from '@angular/http';
+
+import { routing } from './app.routing';
+
+/** Route authorization guards */
+import { AdminGuard } from './shared/admin-guard.service';
+import { SpeakerGuard } from './shared/speaker-guard.service';
+
+/** Root component */
+import { AppComponent }   from './app.component';
+
+/** Components */
+import { HomeComponent } from './admin/home/home.component';
+import { CalendarComponent } from './admin/calendar/calendar.component';
+import { CreateConfComponent } from './admin/create-conf/create-conf.component';
+import { DashboardComponent } from './user/dashboard/dashboard.component';
+import { ModifyConfComponent } from './admin/modify-conf/modify-conf.component';
+import { SelectActiveComponent } from './admin/select-active/select-active.component';
+import { SessionComponent } from './shared/session/session.component';
+import { SessionListComponent } from './admin/session-list/session-list.component';
+import { SpeakerComponent } from './shared/speaker/speaker.component';
+import { SpeakerListComponent } from './admin/speaker-list/speaker-list.component';
+import { LoginComponent } from './auth/login/login.component';
+import { SignupComponent } from './auth/signup/signup.component';
+import { SettingsComponent } from './auth/settings/settings.component';
+import { LandingComponent } from './auth/landing/landing.component';
+import { AdministrationComponent } from './admin/administration/administration.component';
+import { ForgotPasswordComponent } from './auth/forgotpassword/forgotpassword.component';
+
+/** App-wide Services */
+import { AdminService } from './shared/admin.service';
+import { AuthService } from './shared/auth.service';
+import { DateService } from './shared/date.service';
+import { SessionService } from './shared/session.service';
+import { SpeakerService } from './shared/speaker.service';
+import { TransitionService } from './shared/transition.service';
+
+/** Pipes */
+import { DatePipe } from './shared/date.pipe';
+import { CapitalizePipe } from './shared/capitalize.pipe';
+import { TimePipe } from './shared/time.pipe';
+
+@NgModule({
+  imports: [
+    BrowserModule,
+    FormsModule,
+    HttpModule,
+    routing
+  ],
+  declarations: [
+    // Components
+    AppComponent, HomeComponent, CalendarComponent, CreateConfComponent,
+    DashboardComponent, ModifyConfComponent, SelectActiveComponent, SessionComponent,
+    SessionListComponent, SpeakerComponent, SpeakerListComponent, LoginComponent,
+    SignupComponent, SettingsComponent, LandingComponent, AdministrationComponent, 
+    ForgotPasswordComponent,
+
+    // Pipes
+    DatePipe, CapitalizePipe, TimePipe
+  ],
+  providers: [
+    // Route guards
+    AdminGuard, SpeakerGuard,
+    // Services
+    AdminService, AuthService, DateService,
+    SessionService, SpeakerService, TransitionService
+  ],
+  bootstrap: [AppComponent],
+})
+
+export class AppModule { }

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -1,8 +1,10 @@
-import { provideRouter, RouterConfig } from '@angular/router';
+import { Routes, RouterModule } from '@angular/router';
 
+/** Route authorization guards */
 import { AdminGuard } from './shared/admin-guard.service';
 import { SpeakerGuard } from './shared/speaker-guard.service';
 
+/** Routes */
 import { HomeComponent } from './admin/home/home.component';
 import { CalendarComponent } from './admin/calendar/calendar.component';
 import { CreateConfComponent } from './admin/create-conf/create-conf.component';
@@ -20,7 +22,7 @@ import { LandingComponent } from './auth/landing/landing.component';
 import { AdministrationComponent } from './admin/administration/administration.component';
 import { ForgotPasswordComponent } from './auth/forgotpassword/forgotpassword.component';
 
-export const routes: RouterConfig = [
+const appRoutes: Routes = [
   { path: '',                 component: LandingComponent },
   { path: 'home',             component: HomeComponent, canActivate: [AdminGuard] },
   { path: 'calendar',         component: CalendarComponent, canActivate: [AdminGuard] },
@@ -39,6 +41,8 @@ export const routes: RouterConfig = [
   { path: 'forgotpassword',   component: ForgotPasswordComponent }
 ];
 
-export const APP_ROUTER_PROVIDERS = [
-  provideRouter(routes)
+export const appRoutingProviders: any[] = [
+
 ];
+
+export const routing = RouterModule.forRoot(appRoutes);

--- a/src/app/auth/forgotpassword/forgotpassword.component.ts
+++ b/src/app/auth/forgotpassword/forgotpassword.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
-import { REACTIVE_FORM_DIRECTIVES, FormGroup, FormControl, Validators } from '@angular/forms';
-import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import {  Router } from '@angular/router';
 import { AuthService } from '../../shared/auth.service';
 import { TransitionService } from '../../shared/transition.service';
 import { ToastComponent } from '../../shared/toast.component';
@@ -9,8 +9,7 @@ import { ToastComponent } from '../../shared/toast.component';
                moduleId: module.id,
                selector: 'forgotpassword',
                templateUrl: 'forgotpassword.component.html',
-               styleUrls: ['forgotpassword.component.css'],
-               directives: [ToastComponent, ROUTER_DIRECTIVES, REACTIVE_FORM_DIRECTIVES]
+               styleUrls: ['forgotpassword.component.css']
            })
 export class ForgotPasswordComponent implements OnInit {
 

--- a/src/app/auth/landing/landing.component.ts
+++ b/src/app/auth/landing/landing.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+import { Router } from '@angular/router';
 
 import { TransitionService } from '../../shared/transition.service';
 import { ToastComponent } from '../../shared/toast.component';
@@ -8,8 +8,7 @@ import { ToastComponent } from '../../shared/toast.component';
                moduleId: module.id,
                selector: 'landing',
                templateUrl: 'landing.component.html',
-               styleUrls: ['landing.component.css'],
-               directives: [ToastComponent, ROUTER_DIRECTIVES]
+               styleUrls: ['landing.component.css']
            })
 export class LandingComponent implements OnInit {
 

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { REACTIVE_FORM_DIRECTIVES, FormGroup, FormControl, Validators } from '@angular/forms';
-import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
 import { AuthService } from '../../shared/auth.service';
 import { TransitionService } from '../../shared/transition.service';
 import { ToastComponent } from '../../shared/toast.component';
@@ -9,8 +9,7 @@ import { ToastComponent } from '../../shared/toast.component';
                moduleId: module.id,
                selector: 'login',
                templateUrl: 'login.component.html',
-               styleUrls: ['login.component.css'],
-               directives: [ToastComponent, ROUTER_DIRECTIVES, REACTIVE_FORM_DIRECTIVES]
+               styleUrls: ['login.component.css']
            })
 export class LoginComponent implements OnInit {
 

--- a/src/app/auth/settings/settings.component.ts
+++ b/src/app/auth/settings/settings.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
-import { REACTIVE_FORM_DIRECTIVES, FormGroup, FormControl, Validators } from '@angular/forms';
-import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
 import { AuthService } from '../../shared/auth.service';
 import { TransitionService } from '../../shared/transition.service';
 import { ToastComponent } from '../../shared/toast.component';
@@ -9,8 +9,7 @@ import { ToastComponent } from '../../shared/toast.component';
                moduleId: module.id,
                selector: 'settings',
                templateUrl: 'settings.component.html',
-               styleUrls: ['settings.component.css'],
-               directives: [ToastComponent, ROUTER_DIRECTIVES, REACTIVE_FORM_DIRECTIVES]
+               styleUrls: ['settings.component.css']
            })
 export class SettingsComponent implements OnInit {
 

--- a/src/app/auth/signup/signup.component.ts
+++ b/src/app/auth/signup/signup.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { REACTIVE_FORM_DIRECTIVES, FormGroup, FormControl, Validators } from '@angular/forms';
-import { ROUTER_DIRECTIVES, Router } from '@angular/router';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
 import { AuthService } from '../../shared/auth.service';
 import { TransitionService } from '../../shared/transition.service';
 import { ToastComponent } from '../../shared/toast.component';
@@ -9,8 +9,7 @@ import { ToastComponent } from '../../shared/toast.component';
                moduleId: module.id,
                selector: 'signup',
                templateUrl: 'signup.component.html',
-               styleUrls: ['signup.component.css'],
-               directives: [ToastComponent, ROUTER_DIRECTIVES, REACTIVE_FORM_DIRECTIVES]
+               styleUrls: ['signup.component.css']
            })
 
 export class SignupComponent implements OnInit {

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,23 +1,4 @@
-import { bootstrap }    from '@angular/platform-browser-dynamic';
-import { disableDeprecatedForms, provideForms } from '@angular/forms';
-import { enableProdMode } from "@angular/core";
-import { HTTP_PROVIDERS } from '@angular/http';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app.module';
 
-import { AppComponent } from './app.component';
-import { APP_ROUTER_PROVIDERS } from './app.routes';
-import { AdminGuard } from './shared/admin-guard.service';
-import { AuthService } from './shared/auth.service';
-import { SpeakerGuard } from './shared/speaker-guard.service';
-
-// enableProdMode();
-
-bootstrap(AppComponent, [
-  APP_ROUTER_PROVIDERS,
-  AdminGuard,
-  AuthService,
-  disableDeprecatedForms(),
-  provideForms(),
-  HTTP_PROVIDERS,
-  SpeakerGuard
-])
-.catch(error => console.log(error));
+platformBrowserDynamic().bootstrapModule(AppModule);

--- a/src/app/shared/session/session.component.ts
+++ b/src/app/shared/session/session.component.ts
@@ -22,9 +22,7 @@ import { Session } from '../session.model';
   moduleId: module.id,
   selector: 'session',
   templateUrl: 'session.component.html',
-  styleUrls: ['session.component.css'],
-  directives: [ToastComponent],
-  pipes: [TimePipe, DatePipe]
+  styleUrls: ['session.component.css']
 })
 export class SessionComponent implements OnInit, OnDestroy {
 

--- a/src/app/shared/speaker/speaker.component.ts
+++ b/src/app/shared/speaker/speaker.component.ts
@@ -12,8 +12,7 @@ import { Speaker } from '../speaker.model';
   moduleId: module.id,
   selector: 'speaker',
   templateUrl: 'speaker.component.html',
-  styleUrls: ['speaker.component.css'],
-  directives: [ToastComponent]
+  styleUrls: ['speaker.component.css']
 })
 export class SpeakerComponent implements OnInit, OnDestroy {
 


### PR DESCRIPTION
Angular RC-6 has an almost-final api, no more big changes should occur at launch of angular 2 final. Good time to refactor since I was getting npm install issues when I tried to push to heroku due to multiple deprecations. 

Main difference from angular version we were using: 
-Everything you will use globally (shared services, pipes, and components) should be declared at the module level
-In our case, I will just use one module - the root module - to declare everything to simplify our lives
-You still need to import your components and services that you will use in each component, but you no longer need to declare them in the @Component decorator.

Everything else should be pretty much the same. Ang2 final should be out before we are done with the app (end of septemberish) and I'll upgrade one last time to that.

Biggest perk of this will be that angular can now compile as a build step, which reduces the payload size of angular by 60% and removes the build step when the page is loaded. I'll do this once we're closer to releasing our app.
