### PR TITLE
Speaker list - no headshot found

### DIFF
--- a/src/app/admin/speaker-list/speaker-list.component.html
+++ b/src/app/admin/speaker-list/speaker-list.component.html
@@ -17,7 +17,7 @@
                  class="speaker row" (click)="gotoSpeaker(speaker._id)">
               <div class="speaker-left text-center">
                 <img *ngIf="speaker.headshot" [src]="speaker.headshot" class="img-responsive">
-                <p *ngIf="!speaker.headshot">No<br/>Image<br />Found</p>
+                <p *ngIf="!speaker.headshot" class="noHeadshot"><br />No<br/>Image<br />Found</p>
               </div>
               <div class="speaker-right">
                 <div class="name">{{ speaker.salutation | capitalize }} {{ speaker.nameFirst | capitalize }} {{ speaker.nameLast | capitalize }}</div>

--- a/src/app/admin/speaker-list/speaker-list.component.scss
+++ b/src/app/admin/speaker-list/speaker-list.component.scss
@@ -51,3 +51,7 @@
   margin-top: 3px;
   text-align: left;
 }
+
+.noHeadshot {
+  width: 100px;
+}


### PR DESCRIPTION
Updated list of speakers so that if there is no headshot image it displays the text 'No Image Found' centered and has the same 100px width that an image would have
